### PR TITLE
fix: image position on mobile

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -15,6 +15,14 @@ figcaption p {
 
 figure {
 	text-align: center;
+	margin: 0px;
+}
+
+@media (max-width: 480px) {
+	img {
+			width: 100%;
+			height: auto;
+	}
 }
 
 /* Image hover effect */


### PR DESCRIPTION
## Description

Images were not well displayed on mobiles.

## How has this been tested?

Before:
<img width="385" alt="Screenshot 2022-12-04 at 19 21 07" src="https://user-images.githubusercontent.com/28714795/205508554-0abc1bfd-ee27-4970-97cb-442144e6883f.png">

After:
<img width="394" alt="Screenshot 2022-12-04 at 19 20 37" src="https://user-images.githubusercontent.com/28714795/205508564-83e7af9b-a406-4a88-b51f-320af07f33f5.png">

