### PR TITLE
chore: content review by claude

### DIFF
--- a/content/posts/kubernetes/build-an-operator/index.md
+++ b/content/posts/kubernetes/build-an-operator/index.md
@@ -12,12 +12,12 @@ cover:
   caption: Fig 1. Photo from [Unsplash](https://unsplash.com/photos/Esq0ovRY-Zs)
 ---
 
-You’re probably familiar with Kubernetes, but do you know what operators are, how they work, and how to build one?
+You're probably familiar with Kubernetes, but do you know what operators are, how they work, and how to build one?
 If you want to know more, you've come to the right place!
 
 Kubernetes operators is a complicated subject but fortunately, since [their creation](https://web.archive.org/web/20170129131616/https://coreos.com/blog/introducing-operators.html) in 2016, many tools have been developed to simplify the life of engineers.
 
-Without further ado, let’s dive in and learn more about operators!
+Without further ado, let's dive in and learn more about operators!
 
 > **✨ The article was updated to use the latest version of kubebuilder ([v4.2.0](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v4.2.0)), released in August 2024!**
 
@@ -25,37 +25,37 @@ Without further ado, let’s dive in and learn more about operators!
 
 ## What is an operator?
 
-Wait a minute, do you know what [Kubernetes](https://kubernetes.io/) (or k8s) is? Just a quick reminder for everyone, it’s an “open source system to deploy, scale, and manage containerized applications anywhere” developed by [Google Cloud](https://cloud.google.com/learn/what-is-kubernetes).
+Wait a minute, do you know what [Kubernetes](https://kubernetes.io/) (or k8s) is? Just a quick reminder for everyone, it's an "open source system to deploy, scale, and manage containerized applications anywhere" developed by [Google Cloud](https://cloud.google.com/learn/what-is-kubernetes).
 
-Most people use Kubernetes by deploying their applications using native resources such as pods, deployments, services, etc. However, it is possible to extend the capabilities of the software to incorporate its logic to meet specific needs. That’s where the operator comes into place.
+Most people use Kubernetes by deploying their applications using native resources such as pods, deployments, services, etc. However, it is possible to extend the capabilities of the software to incorporate its logic to meet specific needs. That's where the operator comes into place.
 
-> The main goal of an operator is to translate an engineer’s logic into code in order to automate certain tasks beyond what Kubernetes can do natively.
+> The main goal of an operator is to translate an engineer's logic into code in order to automate certain tasks beyond what Kubernetes can do natively.
 
 Engineers dealing with applications or services have a deep knowledge of how the system should behave, how it should be deployed, and how to react in case of a problem. The ability to encapsulate this technical knowledge in code and automate actions means less time is spent on repetitive tasks and more on important issues.
 
 For example, one can imagine an operator deploying and maintaining tools such as [MySQL](https://www.mysql.com/), [Elasticsearch](https://www.elastic.co/), or [Gitlab runners](https://docs.gitlab.com/runner/) in Kubernetes. An operator could configure these tools, adjust the state of the system according to events and react to failures.
 
-Sounds interesting, right? Let’s get our hands dirty.
+Sounds interesting, right? Let's get our hands dirty.
 
-## Practical Work
+## Practical work
 
-You could either build an operator from scratch using the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) project developed by Kubernetes or you could use one of the most popular frameworks to accelerate your development cycle and reduce the complexity ([Kubebuilder](https://book.kubebuilder.io/) or [OperatorSDK](https://sdk.operatorframework.io/)). I’d choose the Kubebuilder framework because it’s very easy to use, the documentation is good, and it’s a battle-tested product. In any case, the two projects are currently being aligned to merge into a single project.
+You could either build an operator from scratch using the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) project developed by Kubernetes or you could use one of the most popular frameworks to accelerate your development cycle and reduce the complexity ([Kubebuilder](https://book.kubebuilder.io/) or [OperatorSDK](https://sdk.operatorframework.io/)). I'd choose the Kubebuilder framework because it's very easy to use, the documentation is good, and it's a battle-tested product. In any case, the two projects are currently being aligned to merge into a single project.
 
 ### 1. Set up your environment
 
-You’ll need some tools to develop your operator. Here are the requisites:
+You'll need some tools to develop your operator. Here are the requisites:
 
 - [go](https://go.dev/doc/install) version v1.20.0+
 - [docker](https://docs.docker.com/get-docker/) version 17.03+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) version v1.11.3+
 
-You'll also need access to a Kubernetes v1.11.3+ cluster. I highly suggest using [kind](https://kind.sigs.k8s.io/) to set up your own local k8s cluster, it’s very easy to use!
+You'll also need access to a Kubernetes v1.11.3+ cluster. I highly suggest using [kind](https://kind.sigs.k8s.io/) to set up your own local k8s cluster, it's very easy to use!
 
 We can then install kubebuilder.
 
 ```sh
 $ curl -L -o kubebuilder \
-    kuhttps://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH) \
+    https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH) \
     && chmod +x kubebuilder \
     && mv kubebuilder /usr/local/bin/
 ```
@@ -71,9 +71,9 @@ Awesome, now we can get started!
 
 ### 2. Create a simple operator
 
-Let’s do a little exercise: we’ll build a simple foo operator which has no real use, except to demonstrate the capabilities of an operator.
+Let's do a little exercise: we'll build a simple foo operator which has no real use, except to demonstrate the capabilities of an operator.
 
-Initialise a new project by running the following command. It will download the controller-runtime binary and scaffold a project that’s ready for us to customise.
+Initialise a new project by running the following command. It will download the controller-runtime binary and scaffold a project that's ready for us to customise.
 
 ```sh
 $ kubebuilder init --domain my.domain --repo my.domain/tutorial
@@ -88,7 +88,7 @@ Next: define a resource with:
 $ kubebuilder create api
 ```
 
-Here’s the structure of the project (as you can notice, it’s a Go project):
+Here's the structure of the project (as you can notice, it's a Go project):
 
 ```sh
 $ ls -la
@@ -112,26 +112,27 @@ drwx------   3 leovct  staff     96 Nov  3 08:49 hack
 drwx------   3 leovct  staff     96 Nov  3 08:49 internal
 ```
 
-Let’s go through the most important components of the operator:
+Let's go through the most important components of the operator:
 
-- `Dockerfile` is the container file used to build the manager’s image.
+- `Dockerfile` is the container file used to build the manager's image.
 - `Makefile` contains handy helper commands.
 - `api/v1` contains the definition of the `Foo` CRD.
 - `cmd/main.go` is the entry point of the project; it sets up and runs the manager.
 - `config/` contains the manifests to deploy the operator and CRDs in Kubernetes.
 - `internal/controller` contains the logic of the `Foo` controller.
 
-**Wait, what’s this controller component?!**
+**Wait, what's this controller component?!**
 
 This is going to be a bit theoretical. Hang on!
 
 > An operator is made of two components, a custom resource definition (CRD) and a controller.
 
-A CRD is a “Kubernetes custom type” or a blueprint of the resource, used to describe its specification and status. We can define instances of the CRD, called custom resources (or CR).
+A CRD is a "Kubernetes custom type" or a blueprint of the resource, used to describe its specification and status. We can define instances of the CRD, called custom resources (or CR).
 
 <!-- prettier-ignore-start -->
 {{< figure
   src="fig-2-crd-cr.svg"
+  alt="Diagram showing a Custom Resource Definition as a blueprint and Custom Resources as instances derived from it"
   caption="Fig 2. Custom Resource Definition (CRD) and Custom Resources (CR)"
   height="400"
   width="700"
@@ -144,6 +145,7 @@ The controller (also called the control loop) continuously monitors the state of
 <!-- prettier-ignore-start -->
 {{< figure
   src="fig-3-controller.svg"
+  alt="Diagram of a Kubernetes controller reconciliation loop: observing cluster state, comparing it to the desired state, and acting to converge the two"
   caption="Fig 3. High-level operation of a controller by [Stefanie Lai](https://medium.com/swlh/kubernetes-operator-for-beginners-what-why-how-21b23f0cb9b1)"
   height="200"
   width="1000"
@@ -155,11 +157,11 @@ In general, a controller is specific to a type of resource but it can perform CR
 
 An example of a controller, presented in the Kubernetes documentation, is the thermostat. When we set the temperature, we tell the thermostat the desired state. The actual state is determined by the actual temperature of the room. The thermostat then reacts to bring the actual state closer to the desired state by turning the heat on or off.
 
-What about the manager then? The goal of this component is to start all the various controllers and makes the set of control loops coexist. Let’s say you have two CRDs in your project. You’ll then have two controllers: one for each CRD. The manager will start these two controllers and make them coexist.
+What about the manager then? The goal of this component is to start all the various controllers and makes the set of control loops coexist. Let's say you have two CRDs in your project. You'll then have two controllers: one for each CRD. The manager will start these two controllers and make them coexist.
 
 _If you want more details on how operators work, you can leave questions in the comments or explore the list of resources provided at the end of the article. I will certainly do a detailed article on this concept in the future_.
 
-Now that we know how an operator works, we can start to create one using the Kubebuilder framework. We’ll start by creating a new API (group/version) and a new Kind (CRD). Press yes when asked to create a CRD and a controller.
+Now that we know how an operator works, we can start to create one using the Kubebuilder framework. We'll start by creating a new API (group/version) and a new Kind (CRD). Press yes when asked to create a CRD and a controller.
 
 ```sh
 $ kubebuilder create api --group tutorial --version v1 --kind Foo
@@ -183,28 +185,29 @@ Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:
 $ make manifests
 ```
 
-This is where the fun starts now! We’ll customise the CRD and the controller to meet our needs. You’ll notice that two new folders have been created:
+This is where the fun starts now! We'll customise the CRD and the controller to meet our needs. You'll notice that two new folders have been created:
 
 - `api/v1` which contains our Foo CRD (see `foo_types.go`).
 - `internal/controllers` which contain the Foo controller (see `foo_controller.go`).
 
 ### 3. Customize the CRD and the controller
 
-Here’s our lovely Foo CRD customised (see `api/v1/foo_types.go`). As I said previously, this CRD has no purpose. It simply shows how you can use operators to perform simple tasks in Kubernetes.
+Here's our lovely Foo CRD customised (see `api/v1/foo_types.go`). As I said previously, this CRD has no purpose. It simply shows how you can use operators to perform simple tasks in Kubernetes.
 
 The Foo CRD has a `name` field in its specification which refers to the name of the friend Foo is looking for. If Foo finds a friend (a pod with the same name as his friend), its `happy` status will be set to `true`.
 
 {{< gist leovct aa3b494eafdc9bdbc2dc705936d9a451 >}}
 
-Now, let’s implement the logic of the controller. Nothing very complicated here. We fetch the Foo resource that triggered the reconciliation request to get the name of Foo’s friend. Then, we list all the pods that have the same name as Foo’s friend. If we find one (or more), we update Foo’s `happy` status to `true`, else we set it to `false`.
+Now, let's implement the logic of the controller. Nothing very complicated here. We fetch the Foo resource that triggered the reconciliation request to get the name of Foo's friend. Then, we list all the pods that have the same name as Foo's friend. If we find one (or more), we update Foo's `happy` status to `true`, else we set it to `false`.
 
-Note that the controller also reacts to Pod events (see `mapPodsReqToFooReq`). Indeed, if a new pod is created, we want the Foo resource to be able to update its status accordingly. This method will be triggered each time a Pod event happens (creation, update, or deletion). It then triggers a reconciliation loop of the Foo controller only if the name of the `Pod` is a “friend” of one of the Foo custom resources deployed in the cluster.
+Note that the controller also reacts to Pod events (see `mapPodsReqToFooReq`). Indeed, if a new pod is created, we want the Foo resource to be able to update its status accordingly. This method will be triggered each time a Pod event happens (creation, update, or deletion). It then triggers a reconciliation loop of the Foo controller only if the name of the `Pod` is a "friend" of one of the Foo custom resources deployed in the cluster.
 
 A picture is worth more than 1000 words so here is an overview of how the operator works.
 
 <!-- prettier-ignore-start -->
 {{< figure
   src="fig-4-foo-operator-overview.svg"
+  alt="Architecture diagram of the Foo operator: the controller watches Foo custom resources and Pods, then updates each Foo's happy status based on whether a matching pod exists"
   caption="Fig 4. Overview of the operator's functioning"
   height="400"
   width="700"
@@ -216,7 +219,7 @@ And now, here is the implementation of the controller.
 
 {{< gist leovct 24b53d11662fa7b8d14721edc3f58b0d >}}
 
-We’re done editing the API definitions and the controller so we can run the following command to update the operator manifests. If you pay attention, you’ll see that some manifest files have been updated.
+We're done editing the API definitions and the controller so we can run the following command to update the operator manifests. If you pay attention, you'll see that some manifest files have been updated.
 
 ```sh
 $ make manifests
@@ -225,7 +228,7 @@ $ make manifests
 
 ### 4. Run the controller
 
-I’m using a local Kubernetes cluster set up with kind, and I advise you to do the same. It’s very easy to use.
+I'm using a local Kubernetes cluster set up with kind, and I advise you to do the same. It's very easy to use.
 
 First, we install the CRDs into the cluster.
 
@@ -272,7 +275,7 @@ As you can see, the manager started and then the Foo controller started. The con
 
 ### 5. Test the controller
 
-To test that everything works properly, we’ll create two Foo custom resources and some pods just to see how the controller behaves. You can modify `config/samples/tutorial_v1_foo.yaml`.
+To test that everything works properly, we'll create two Foo custom resources and some pods just to see how the controller behaves. You can modify `config/samples/tutorial_v1_foo.yaml`.
 
 First, create the Foo custom resources manifests in config/samples and run the following command to create the resources in your local Kubernetes cluster.
 
@@ -286,7 +289,7 @@ foo.tutorial.my.domain/foo-2 created
 
 You should see that the controller triggered two reconciliation loops for each Foo custom resource creation event. You may wonder why two loops were triggered for each custom resource and not one, this is a more technical topic, I invite you to read this [thread](https://github.com/leovct/kube-operator-tutorial/issues/2).
 
-```sh
+```text
 2023-11-03T09:16:40+01:00       INFO    reconciling foo custom resource {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-sample","namespace":"default"}, "namespace": "default", "name": "foo-sample", "reconcileID": "c98a2469-159f-4c3f-b9bb-aa02b6dd5bf9"}
 2023-11-03T09:16:40+01:00       INFO    foo's happy status updated      {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-sample","namespace":"default"}, "namespace": "default", "name": "foo-sample", "reconcileID": "c98a2469-159f-4c3f-b9bb-aa02b6dd5bf9", "status": false}
 2023-11-03T09:16:40+01:00       INFO    foo custom resource reconciled  {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-sample","namespace":"default"}, "namespace": "default", "name": "foo-sample", "reconcileID": "c98a2469-159f-4c3f-b9bb-aa02b6dd5bf9"}
@@ -295,7 +298,7 @@ You should see that the controller triggered two reconciliation loops for each F
 2023-11-03T09:16:40+01:00       INFO    foo custom resource reconciled  {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-sample","namespace":"default"}, "namespace": "default", "name": "foo-sample", "reconcileID": "d747fc5a-3465-4c56-843f-0f4d87d2e3f0"}
 ```
 
-If you check the status of the Foo custom resources, you can see that their status is empty. That’s exactly what we expect so everything’s good so far!
+If you check the status of the Foo custom resources, you can see that their status is empty. That's exactly what we expect so everything's good so far!
 
 ```sh
 $ kubectl describe foos
@@ -341,13 +344,13 @@ Status:
 Events:  <none>
 ```
 
-Now, let’s spice things up! We’ll deploy a pod named `jack` to see how the system reacts.
+Now, let's spice things up! We'll deploy a pod named `jack` to see how the system reacts.
 
 {{< gist leovct fa9cc578ada581f0c32cff14515cc2e2 >}}
 
 Once done, you should see that the controller reacts to the pod creation event. It then updates the status of the first Foo custom resource as expected. You can verify by yourself by describing the Foo custom resources.
 
-```sh
+```text
 2023-11-03T09:26:25+01:00       INFO    pod linked to a foo custom resource issued an event     {"name": "jack"}
 2023-11-03T09:26:25+01:00       INFO    pod linked to a foo custom resource issued an event     {"name": "jack"}
 2023-11-03T09:26:25+01:00       INFO    reconciling foo custom resource {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-01","namespace":"default"}, "namespace": "default", "name": "foo-01", "reconcileID": "ec16b29b-4bae-4909-8392-8966c3e10ad4"}
@@ -356,9 +359,9 @@ Once done, you should see that the controller reacts to the pod creation event. 
 2023-11-03T09:26:25+01:00       INFO    foo custom resource reconciled  {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-01","namespace":"default"}, "namespace": "default", "name": "foo-01", "reconcileID": "ec16b29b-4bae-4909-8392-8966c3e10ad4"}
 ```
 
-Let’s update the specification of the second Foo custom resource and change the value of its name field from `joe` to `jack`. The controller should catch the update event and trigger a reconciliation loop.
+Let's update the specification of the second Foo custom resource and change the value of its name field from `joe` to `jack`. The controller should catch the update event and trigger a reconciliation loop.
 
-```sh
+```text
 2023-11-03T09:27:18+01:00       INFO    pod linked to a foo custom resource issued an event     {"name": "joe"}
 2023-11-03T09:27:18+01:00       INFO    pod linked to a foo custom resource issued an event     {"name": "joe"}
 2023-11-03T09:27:18+01:00       INFO    reconciling foo custom resource {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-02","namespace":"default"}, "namespace": "default", "name": "foo-02", "reconcileID": "d7e94353-94ae-4883-b5de-1d50c966448f"}
@@ -367,26 +370,26 @@ Let’s update the specification of the second Foo custom resource and change th
 2023-11-03T09:27:18+01:00       INFO    foo custom resource reconciled  {"controller": "foo", "controllerGroup": "tutorial.my.domain", "controllerKind": "Foo", "Foo": {"name":"foo-02","namespace":"default"}, "namespace": "default", "name": "foo-02", "reconcileID": "d7e94353-94ae-4883-b5de-1d50c966448f"}
 ```
 
-Yeah, it worked! Enough tests for today; I think you got it! If you delete the pod named `jack`, the custom resources’ `happy` status will be set back to `false`.
+Yeah, it worked! Enough tests for today; I think you got it! If you delete the pod named `jack`, the custom resources' `happy` status will be set back to `false`.
 
-We can confirm that the operator works as expected! It would be better to write unit and e2e tests but that’s not the purpose of this article, i’ll cover this topic in another article.
+We can confirm that the operator works as expected! It would be better to write unit and e2e tests but that's not the purpose of this article—I'll cover this topic in another article.
 
-You can be proud of yourself. You have designed, deployed, and tested your very first operator! Congratulations!!
+You can be proud of yourself. You have designed, deployed, and tested your very first operator. Congratulations!
 
-Here’s the link to the [GitHub repository](https://github.com/leovct/kube-operator-tutorial) if you need to browse the code.
+Here's the link to the [GitHub repository](https://github.com/leovct/kube-operator-tutorial) if you need to browse the code.
 
 ## To go further
 
-We’ve seen how to create a very basic Kubernetes operator and it’s far from being perfect. There are many ways to improve it. Here’s a list of topics you can explore if you want.
+We've seen how to create a very basic Kubernetes operator and it's far from being perfect. There are many ways to improve it. Here's a list of topics you can explore if you want.
 
-- Optimise event filtering (sometimes, events are submitted twice…)
-- Refine RBAC permissions
-- Improve the logging system
-- Issue Kubernetes events when resources are updated by the operator
-- Add custom fields when getting Foo custom resources (display the `happy` status maybe?)
-- Write unit tests and e2e tests
+- Optimise event filtering (sometimes, events are submitted twice…).
+- Refine RBAC permissions.
+- Improve the logging system.
+- Issue Kubernetes events when resources are updated by the operator.
+- Add custom fields when getting Foo custom resources (display the `happy` status maybe?).
+- Write unit tests and e2e tests.
 
-Here’s a list of resources you can use to dig deeper into the subject.
+Here's a list of resources you can use to dig deeper into the subject.
 
 - <https://youtu.be/i9V4oCa5f9I>
 - <https://book.kubebuilder.io/>

--- a/content/posts/kubernetes/write-tests-for-operators/index.md
+++ b/content/posts/kubernetes/write-tests-for-operators/index.md
@@ -1,8 +1,8 @@
 ---
 author: leovct
 title: 🧪 Write tests for Kubernetes operators
-date: 2022-08-01
 description: Learn how to write unit and e2e tests for Kubernetes operators
+date: 2022-08-01
 tags:
   - kubernetes
   - go
@@ -12,40 +12,40 @@ cover:
   caption: Fig 1. Photo from [Unsplash](https://unsplash.com/photos/aYHzEnSEH-w)
 ---
 
-You know how to build a kubernetes operator? Cool. Now, it’s time to get serious!
+You know how to build a kubernetes operator? Cool. Now, it's time to get serious!
 
 Let's write some tests to use our operator in production!
 
-In my previous [article](https://leovct.github.io/posts/build-a-kubernetes-operator-in-10-minutes/), I showed how to build a Kubernetes operator in about ten minutes - but you must be quick haha! I’ve also described the functioning of an operator, the custom resource definition and custom resources, the controllers, and the manager. If you want to learn more about these concepts, I highly recommend you read the article.
+In my previous [article]({{< ref "/posts/kubernetes/build-an-operator" >}}), I showed how to build a Kubernetes operator in about ten minutes. I've also described the functioning of an operator, the custom resource definition and custom resources, the controllers, and the manager. If you want to learn more about these concepts, I highly recommend you read the article.
 
-But now it’s time to write some tests to use our operator in production! It’s a subject in its own right that is less complicated than it seems. Most people don’t like writing tests, but they are necessary. They help to improve code quality, detect bugs, and save time and money. So, let’s do some testing!
+But now it's time to write some tests to use our operator in production! It's a subject in its own right that is less complicated than it seems. Most people don't like writing tests, but they are necessary. They help to improve code quality, detect bugs, and save time and money. So, let's do some testing!
 
 > **✨ The article was updated to use the latest version of kubebuilder ([v4.2.0](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v4.2.0)), released in August 2024!**
 
-## The Different Types of Tests
+## The different types of tests
 
-There are three major types of testing in software development: unit, integration, and end-to-end testing. It is even more complex than that in theory, but it gives an idea of what we’ll see in this article.
+There are three major types of testing in software development: unit, integration, and end-to-end testing. It is even more complex than that in theory, but it gives an idea of what we'll see in this article.
 
 - **Unit tests** are used to test small pieces of code, for example, methods or functions.
 - **Integration tests** are used to test the integration of the different parts of an application. For example, the functioning of an operator in a Kubernetes environment with an API server and other resources.
-- **End-to-end tests**, also known as e2e, aim to simulate a user’s step-by-step experience. They should cover the main functionalities of the application. In the practical work that follows, we’ll see how to write unit tests in Go as well as integration tests for Kubernetes controllers. It’s interesting, you’ll see!
+- **End-to-end tests**, also known as e2e, aim to simulate a user's step-by-step experience. They should cover the main functionalities of the application. In the practical work that follows, we'll see how to write unit tests in Go as well as integration tests for Kubernetes controllers. It's interesting, you'll see!
 
-## Practical Work
+## Practical work
 
 ### 1. Set up your environment
 
-I choose to use the [Kubebuilder](https://book.kubebuilder.io/) framework to build Kubernetes operators. It’s very easy to use, the documentation is easy to read, and it’s a battle-tested product. It’s one of the two most popular Go frameworks to build operators, along with [Operator SDK](https://sdk.operatorframework.io/).
+I choose to use the [Kubebuilder](https://book.kubebuilder.io/) framework to build Kubernetes operators. It's very easy to use, the documentation is easy to read, and it's a battle-tested product. It's one of the two most popular Go frameworks to build operators, along with [Operator SDK](https://sdk.operatorframework.io/).
 
-I assume you already have the necessary tools to design an operator (`go`, `docker`, `kubectl`, `kubebuilder` and a small local Kubernetes cluster). But if this is not the case, I strongly recommend that you follow the following [installation steps](https://leovct.github.io/posts/build-a-kubernetes-operator-in-10-minutes/#1-set-up-your-environment) so that you can follow along with me during this tutorial.
+I assume you already have the necessary tools to design an operator (`go`, `docker`, `kubectl`, `kubebuilder` and a small local Kubernetes cluster). But if this is not the case, I strongly recommend that you follow the following [installation steps]({{< ref "/posts/kubernetes/build-an-operator#1-set-up-your-environment" >}}) so that you can follow along with me during this tutorial.
 
-To focus only on the testing part, I have prepared a simple Kubernetes operator, designed with Kubebuilder. This practical work will be to write tests to validate that the operator’s code meets our expectations and ensure that it does not contain any bugs. I’m going to ask you to clone the project and move to the `operator-v2` directory so we all start from the same base.
+To focus only on the testing part, I have prepared a simple Kubernetes operator, designed with Kubebuilder. This practical work will be to write tests to validate that the operator's code meets our expectations and ensure that it does not contain any bugs. I'm going to ask you to clone the project and move to the `operator-v2` directory so we all start from the same base.
 
 ```sh
 $ git clone git@github.com:leovct/kubernetes-operator-tutorial.git \
     && cd kubernetes-operator-tutorial/operator-v2
 ```
 
-If you try to run tests, you’ll see that the coverage equals 0%. Indeed, we haven’t written any tests yet! But this is going to change!
+If you try to run tests, you'll see that the coverage equals 0%. Indeed, we haven't written any tests yet! But this is going to change!
 
 ```sh
 $ make test
@@ -59,7 +59,7 @@ ok      my.domain/tutorial/internal/controller  2.129s  coverage: 0.0% of statem
 
 ### 2. Some context on the operator
 
-The “Foo” operator you cloned is similar to the one I built in my “[Build a Kubernetes Operator in 10 minutes](https://leovct.github.io/posts/build-a-kubernetes-operator-in-10-minutes/)” article. It has no real purpose except to show how you can use operators to perform simple tasks in Kubernetes.
+The "Foo" operator you cloned is similar to the one I built in my "[Build a Kubernetes operator in 10 minutes]({{< ref "/posts/kubernetes/build-an-operator" >}})" article. It has no real purpose except to show how you can use operators to perform simple tasks in Kubernetes.
 
 How does the operator work?
 
@@ -68,6 +68,7 @@ Because a diagram explains ideas way better than three paragraphs, here it is.
 <!-- prettier-ignore-start -->
 {{< figure
   src="fig-2-foo-operator-overview.svg"
+  alt="Architecture diagram of the Foo operator: the controller watches Foo custom resources and Pods, then updates each Foo's happy and color status based on whether a matching pod exists"
   caption="Fig 2. Overview of the operator's functioning"
   height="400"
   width="700"
@@ -77,21 +78,21 @@ Because a diagram explains ideas way better than three paragraphs, here it is.
 
 First, there is the Foo Custom Resource Definition or CRD (see `api/v1/foo_types.go`). It has a `name` field in its specification which refers to the name of the friend Foo is looking for. If Foo finds a friend (a Pod with the same name as his friend), its `happy` status will be set to `true`. A small addition since the previous tutorial, the status of Foo also contains a `color` field, determined according to its name and the namespace in which it evolves.
 
-Second, there is the Foo Controller (see `controllers/foo_controller.go`). It fetches the Foo resource that triggered the reconciliation request to get the name of Foo’s friend. Then, it lists all the pods with the same name as Foo’s friend. If at least one friend has been found, it updates Foo’s `happy` status to `true`, else we set it to `false`. It also updates Foo’s `color` status.
+Second, there is the Foo Controller (see `controllers/foo_controller.go`). It fetches the Foo resource that triggered the reconciliation request to get the name of Foo's friend. Then, it lists all the pods with the same name as Foo's friend. If at least one friend has been found, it updates Foo's `happy` status to `true`, else we set it to `false`. It also updates Foo's `color` status.
 
-Note that the controller also reacts to Pod events (see `mapPodsReqToFooReq`). Indeed, if a new pod is created, we want the Foo resource to be able to update its status accordingly. This method will be triggered each time a Pod event happens (creation, update, or deletion). It then triggers a reconciliation loop of the Foo controller only if the Pod's name is a “friend” of one of the Foo custom resources deployed in the cluster.
+Note that the controller also reacts to Pod events (see `mapPodsReqToFooReq`). Indeed, if a new pod is created, we want the Foo resource to be able to update its status accordingly. This method will be triggered each time a Pod event happens (creation, update, or deletion). It then triggers a reconciliation loop of the Foo controller only if the Pod's name is a "friend" of one of the Foo custom resources deployed in the cluster.
 
 Now that we know how the operator works, we can get on with testing it.
 
 ### 3. Unit tests
 
-At this stage, we will test small pieces of code like methods and functions. Of course, we won’t test the controller `Reconcile` method here because it involves setting up a testing Kubernetes environment with a local Kubernetes API server, the CRD, the controller, the manager, etc. We’ll see this in the 4. Integration tests section instead.
+At this stage, we will test small pieces of code like methods and functions. Of course, we won't test the controller `Reconcile` method here because it involves setting up a testing Kubernetes environment with a local Kubernetes API server, the CRD, the controller, the manager, etc. We'll see this in the 4. Integration tests section instead.
 
-What are we going to test then? If you take the time to read the code of the Foo controller, you’ll notice that I use the `ConvertStrToColor` function from the `color` package to update Foo’s `color` status. Let’s write the unit tests of this simple method!
+What are we going to test then? If you take the time to read the code of the Foo controller, you'll notice that I use the `ConvertStrToColor` function from the `color` package to update Foo's `color` status. Let's write the unit tests of this simple method!
 
 {{< gist leovct 786b5c520dbbfaa60d16b5897b0532fb >}}
 
-Our goal here is to make sure that the function returns what is expected given the input parameters. Here are the three tests I’d like to write to test this function:
+Our goal here is to make sure that the function returns what is expected given the input parameters. Here are the three tests I'd like to write to test this function:
 
 1. Convert an empty string to a colour of the colour wheel.
 2. Convert a short string to a colour of the colour wheel.
@@ -101,7 +102,7 @@ To write unit tests in Go, you create a list of tests describing the name, input
 
 {{< gist leovct e0d7563e278c1a4d25ea3e823d3515aa >}}
 
-Now, if you attempt to run the tests a second time, you’ll see that the code coverage of the `color` package is equal to 100%! Awesome, we did it! The function works as expected.
+Now, if you attempt to run the tests a second time, you'll see that the code coverage of the `color` package is equal to 100%! Awesome, we did it! The function works as expected.
 
 ```sh
 $ make test
@@ -113,29 +114,29 @@ ok      my.domain/tutorial/internal/color       0.319s  coverage: 100.0% of stat
 ok      my.domain/tutorial/internal/controller  2.109s  coverage: 0.0% of statements
 ```
 
-Now, let’s get down to business. We’re going to test how the operator’s reconciliation loop! Trust me, this is the most interesting part of the article!
+Now, let's test the operator's reconciliation loop.
 
 ### 4. Integration tests
 
 Kubebuilder provided a test boilerplate (see `controllers/suite_test.go`) that sets up a testing environment with a local Kubernetes API server. The only thing we need to do is first instantiate and run the controller and then write tests with [Ginkgo](https://onsi.github.io/ginkgo/) (framework used by Kubebuilder) to verify that our operator behaves well when it evolves in a Kubernetes environment.
 
-Of course, this test environment is very simple and often does not represent the environment of a production cluster. This is why running the operator’s tests in an existing cluster is also possible to get closer to a real production environment. You can learn more about that [here](https://book.kubebuilder.io/reference/envtest.html).
+Of course, this test environment is very simple and often does not represent the environment of a production cluster. This is why running the operator's tests in an existing cluster is also possible to get closer to a real production environment. You can learn more about that [here](https://book.kubebuilder.io/reference/envtest.html).
 
-First, we’ll need to instantiate and start the Foo controller. To do this, we need to create another client. Why do we need two clients? Because when running tests, you want to assert against the live state of the API server. If you use the client from the manager in your tests, you’d end up asserting against the content of the cache instead. First, this is slower. Second, this can introduce flaws. That’s why we’ve got two clients: `k8sclient`, the client we’ll use in our tests, and `k8sManager.getClient()`, the manager's client.
+First, we'll need to instantiate and start the Foo controller. To do this, we need to create another client. Why do we need two clients? Because when running tests, you want to assert against the live state of the API server. If you use the client from the manager in your tests, you'd end up asserting against the content of the cache instead. First, this is slower. Second, this can introduce flaws. That's why we've got two clients: `k8sclient`, the client we'll use in our tests, and `k8sManager.getClient()`, the manager's client.
 
 Here is the modified source code of the test environment setup.
 
 {{< gist leovct 47dceaf7d524ae7be9850ad8ae02b791 >}}
 
-Now that our test environment is properly set up, we can write integration tests! Let’s create a new test file called `foo_controller_test.go` under the `controllers` folder. In this file, we’ll define our tests using the Ginkgo framework. Here’s a simple test example that creates two Foo custom resources and ensures that the resources have been created.
+Now that our test environment is properly set up, we can write integration tests! Let's create a new test file called `foo_controller_test.go` under the `controllers` folder. In this file, we'll define our tests using the Ginkgo framework. Here's a simple test example that creates two Foo custom resources and ensures that the resources have been created.
 
 {{< gist leovct 025628faea88b93c561f490d2a1e51f2 >}}
 
-Great! Now let’s write a test that creates a pod with the same name as one of the Foo custom resources’ friends. The controller should update the status of the custom resource and set it to `true`. The other custom resource should still have its status set to `false`.
+Great! Now let's write a test that creates a pod with the same name as one of the Foo custom resources' friends. The controller should update the status of the custom resource and set it to `true`. The other custom resource should still have its status set to `false`.
 
 {{< gist leovct b65dcf88ae6218f1d9fa7e7cc1d6502a >}}
 
-Let’s write another test that updates the name of the second Foo custom resource’s friend to the name of the previously created pod. The controller should update the status of the custom resource and set it to `true`. Again, the other custom resource should still have its status set to `false`.
+Let's write another test that updates the name of the second Foo custom resource's friend to the name of the previously created pod. The controller should update the status of the custom resource and set it to `true`. Again, the other custom resource should still have its status set to `false`.
 
 {{< gist leovct 0f7398a6facaf18451a91ce68891cf8f >}}
 
@@ -145,7 +146,7 @@ Our final test for today will be to delete the pod we created and check that the
 
 These are fairly simple tests, but they show you the possibilities. You can do very complex things using the various tools provided by Ginkgo. If you paid attention during the tutorial, you should have seen various instructions such as `Expect`, `Eventually`, or `Consistently`, which are very useful methods to test the behaviour of the operator and the resources running in Kubernetes.
 
-We’ve written many great tests that cover our controller's scope. Now it’s time to run them to see if the operator passes them all.
+We've written many great tests that cover our controller's scope. Now it's time to run them to see if the operator passes them all.
 
 ```sh
 $ make test
@@ -157,15 +158,15 @@ ok      my.domain/tutorial/internal/color       0.443s  coverage: 100.0% of stat
 ok      my.domain/tutorial/internal/controller  16.166s coverage: 81.8% of statements
 ```
 
-Nice, we’ve got no errors! In addition, we went from 0% coverage to over 82%! The last 18% corresponds to the parts of the code that we can’t test (or maybe using mocks but it would be a lot of work for not much). For example, when the controller can’t find the custom resource that triggered the reconciliation loop or when it can’t list the pods in the cluster. It doesn’t matter because we know that we have tested all the operator’s scope.
+Nice, we've got no errors! In addition, we went from 0% coverage to over 82%! The last 18% corresponds to the parts of the code that we can't test (or maybe using mocks but it would be a lot of work for not much). For example, when the controller can't find the custom resource that triggered the reconciliation loop or when it can't list the pods in the cluster. It doesn't matter because we know that we have tested all the operator's scope.
 
-Here’s the link to the [GitHub repository](https://github.com/leovct/kube-operator-tutorial) if you need to browse the code. The `operator-v2` directory contains the source code of the operator without the tests, while the `operator-v2-with-tests` directory contains the source code with all the tests.
+Here's the link to the [GitHub repository](https://github.com/leovct/kube-operator-tutorial) if you need to browse the code. The `operator-v2` directory contains the source code of the operator without the tests, while the `operator-v2-with-tests` directory contains the source code with all the tests.
 
-## To Go Further
+## To go further
 
-We’ve seen how to write unit tests and integration tests for Kubernetes controllers using the Ginkgo framework. It is a crucial step in developing Kubernetes operators as it allows for validating the correct functioning of the reconciliation logic.
+We've seen how to write unit tests and integration tests for Kubernetes controllers using the Ginkgo framework. It is a crucial step in developing Kubernetes operators as it allows for validating the correct functioning of the reconciliation logic.
 
-Also, here’s a list of resources you can use to dig deeper into the subject.
+Also, here's a list of resources you can use to dig deeper into the subject.
 
 - <https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html>
 - <https://book.kubebuilder.io/reference/envtest.html>


### PR DESCRIPTION
- Fix broken install command: kuhttps:// → https:// (build-an-operator)
- Fix broken self-referencing URLs in write-tests post: hardcoded /posts/build-a-kubernetes-operator-in-10-minutes/ (404 in prod) replaced with Hugo {{< ref >}} shortcodes pointing to the actual slug
- Convert smart quotes (curly ‘ ’ “ ”) to straight quotes throughout
- Capitalise lowercase i'll typo
- Align frontmatter field order between the two posts
- Code blocks: ```sh → ```text for pure log output (3 blocks)
- Headers: consistent sentence case ("To go further", "Practical work", "The different types of tests")
- Add explicit alt text to all 4 figure shortcodes
- Trim "Congratulations!!" → "Congratulations!"
- Add terminal periods to "To go further" bullet list
- Tone down two of the most informal Medium-era interjections